### PR TITLE
Fix httprunner repository link

### DIFF
--- a/site/src/data/clients.yaml
+++ b/site/src/data/clients.yaml
@@ -119,7 +119,7 @@ clients:
     type: cli
     platform: CLI, TUI, GUI
     language: Rust
-    repo: https://github.com/chelle-helle/httprunner
+    repo: https://github.com/christianhelle/httprunner
     description: >
       Rust-based CLI/TUI/GUI supporting both JetBrains and REST Client syntax,
       http-client.env.json, and HTML/Markdown report generation.


### PR DESCRIPTION
## Summary
- fix the httprunner repository URL in the client data
- point it to christianhelle/httprunner instead of the dead chelle-helle/httprunner link

Closes #2