### PR TITLE
docs: add Resterm client entry

### DIFF
--- a/site/src/content/docs/clients/cli.mdoc
+++ b/site/src/content/docs/clients/cli.mdoc
@@ -25,6 +25,12 @@ The same broad compatibility as the httpyac VS Code extension — supports both 
 
 Rust-based CLI with TUI and GUI modes. Supports both JetBrains and REST Client syntax, `http-client.env.json`, and HTML/Markdown report generation.
 
+## Resterm
+
+{% client-card id="resterm" /%}
+
+Terminal API client for `.http` and `.rest` files with support for HTTP, GraphQL, gRPC, WebSockets, SSE, workflows, SSH tunnels, profiling, OpenAPI, Kubernetes port-forwarding, and headless execution.
+
 ## Kulala CLI
 
 {% client-card id="kulala-cli" /%}

--- a/site/src/content/docs/clients/overview.mdoc
+++ b/site/src/content/docs/clients/overview.mdoc
@@ -27,6 +27,7 @@ The `.http` file format is supported by at least 15 actively maintained tools. T
 {% client-card id="ijhttp" /%}
 {% client-card id="httpyac-cli" /%}
 {% client-card id="httprunner" /%}
+{% client-card id="resterm" /%}
 {% client-card id="kulala-cli" /%}
 {% client-card id="httprun" /%}
 {% client-card id="dot-http" /%}

--- a/site/src/content/docs/guides/choose-a-client.mdoc
+++ b/site/src/content/docs/guides/choose-a-client.mdoc
@@ -48,6 +48,7 @@ Built into Visual Studio 2022 since v17.6. Supports the JetBrains environment fo
 {% client-grid %}
 {% client-card id="ijhttp" /%}
 {% client-card id="httpyac-cli" /%}
+{% client-card id="resterm" /%}
 {% client-card id="kulala-cli" /%}
 {% /client-grid %}
 

--- a/site/src/data/clients.yaml
+++ b/site/src/data/clients.yaml
@@ -124,6 +124,20 @@ clients:
       Rust-based CLI/TUI/GUI supporting both JetBrains and REST Client syntax,
       http-client.env.json, and HTML/Markdown report generation.
 
+  resterm:
+    name: Resterm
+    shortName: Resterm
+    author: unkn0wn-root
+    type: cli
+    platform: CLI, TUI
+    language: Go
+    repo: https://github.com/unkn0wn-root/resterm
+    docs: https://github.com/unkn0wn-root/resterm#readme
+    description: >
+      Terminal API client for .http and .rest files with support for HTTP,
+      GraphQL, gRPC, WebSockets, SSE, workflows, SSH tunnels, profiling,
+      OpenAPI, Kubernetes port-forwarding, and headless execution.
+
   kulala-cli:
     name: Kulala CLI
     shortName: kulala CLI


### PR DESCRIPTION
﻿## Summary
- add `Resterm` to the client registry in `site/src/data/clients.yaml`
- add a dedicated `Resterm` section to the CLI tools page
- include `Resterm` in the CLI tools overview and the CI/CD client chooser

## Why
`Resterm` is another actively maintained `.http` / `.rest` client and should be listed alongside the other documented CLI implementations.

## Testing
- reviewed the diff to confirm the change is limited to the client registry and documentation pages
- attempted `npm.cmd run build`, but the local environment does not have `astro` available on PATH
