### PR TITLE
docs: add kulala-cli docs URL

### DIFF
--- a/site/src/data/clients.yaml
+++ b/site/src/data/clients.yaml
@@ -132,6 +132,7 @@ clients:
     platform: CLI (requires Neovim + curl)
     language: Lua
     repo: https://github.com/mistweaverco/kulala-cli
+    docs: https://github.com/mistweaverco/kulala-cli#readme
     description: >
       CLI companion to kulala.nvim. GitHub Action available for CI pipelines.
 

--- a/site/src/data/clients.yaml
+++ b/site/src/data/clients.yaml
@@ -132,7 +132,7 @@ clients:
     platform: CLI (requires Neovim + curl)
     language: Lua
     repo: https://github.com/mistweaverco/kulala-cli
-    docs: https://github.com/mistweaverco/kulala-cli#readme
+    docs: https://kulala.app/usage
     description: >
       CLI companion to kulala.nvim. GitHub Action available for CI pipelines.
 


### PR DESCRIPTION
﻿## Summary
- add a docs URL for `kulala-cli` in `site/src/data/clients.yaml`

## Why
The client registry now points readers to the official `kulala-cli` documentation instead of only the repo URL.

## Testing
- reviewed the diff to confirm the change is limited to the `kulala-cli` entry in `site/src/data/clients.yaml`
