### PR TITLE
docs: add httprun docs URL

### DIFF
--- a/site/src/data/clients.yaml
+++ b/site/src/data/clients.yaml
@@ -143,6 +143,7 @@ clients:
     platform: CLI
     language: C#
     repo: https://github.com/api1st/httprun
+    docs: https://github.com/api1st/httprun#readme
     description: >
       CLI targeting VS Code REST Client compatibility. Supports batch execution
       of .http files with configurable timeouts and success codes.


### PR DESCRIPTION
﻿## Summary
- add a docs URL for `httprun` in `site/src/data/clients.yaml`

## Why
The client registry should link readers to the official `httprun` documentation entry point instead of only the repository URL.

## Testing
- reviewed the diff to confirm the change is limited to the `httprun` entry in `site/src/data/clients.yaml`
